### PR TITLE
Feature/theme palette extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This library simplifies the process of building consistent and visually appealin
 
 # Features
 * Generate a color palette based on a single input color. Using color alpha/mat-colors
-* Create a complete theme color set, including primary, secondary, background, and surface colors.
+* Create a complete theme color schemas, including primary, secondary, background, and surface colors.
 * Support for Material Design color guidelines.
 * Easy integration with Android projects.
 
@@ -26,13 +26,13 @@ Add the following dependency to your `build.gradle` / `build.gradle.kts` file:
 For Groovy - `build.gradle`:
 ````
 dependencies {
-    implementation 'com.github.KvColorPalette:KvColorPalette-Android:1.2.1'
+    implementation 'com.github.KvColorPalette:KvColorPalette-Android:2.0.0'
 }
 ````
 For Kotlin DSL - `build.gradle.kts`:
 ````
 dependencies {
-    implementation("com.github.KvColorPalette:KvColorPalette-Android:1.2.1")
+    implementation("com.github.KvColorPalette:KvColorPalette-Android:2.0.0")
 }
 ````
 
@@ -68,9 +68,9 @@ override fun onCreate() {
     KvColorPalette.initialize(Color.blue)
 }
 ````
-This initiation create a color set for a theme using the given color at the initiation. This generated color set available for light and dark theme variants.
+This initiation create a color schemas for a theme using the given color at the initiation. This generated color schemas will available for light and dark theme variants.
 
-In this `KvColorPalette.appThemePalette` you will have following color attributes.
+In this `KvColorPalette.colorSchemeThemePalette` you will have following color attributes.
 |Attribute    |light-theme |dark-theme  |Description   |
 |-------------|------------|------------|--------------|
 |.base        |original    |original    |This is the base color given by the user.   |
@@ -83,9 +83,12 @@ In this `KvColorPalette.appThemePalette` you will have following color attribute
 |.onSecondary |available   |available   |This is the color you can use on any component use secondary color.   |
 |.shadow      |available   |available   |This is the color for your shadows.   |
 
+This `ColorSchemaThemePalette` is another Android Jetpack Compose `ColorSchema`. But that contains additional attributes like `base`, `quaternary`, `shadow` that provide 
+by the `KvColorPalette-Android` library. All above table mentioned colors are generated according to the given color and created the `ColorScheme`.
+
 ### Use generated theme
 As mentioned above, according to the initiation color, that generate the color set for light and dark them.
-In your Jetpack Compose project, you can assign generate color set the your application theme.
+In your Jetpack Compose project, you can assign generate color schemas to your application theme.
 ````
     // Generate the color schema
     val appColorScheme = when {

--- a/README.md
+++ b/README.md
@@ -87,33 +87,10 @@ In this `KvColorPalette.appThemePalette` you will have following color attribute
 As mentioned above, according to the initiation color, that generate the color set for light and dark them.
 In your Jetpack Compose project, you can assign generate color set the your application theme.
 ````
-    // Access the generated theme color set from KvColorPalette-Android library
-    val theme = KvColorPalette.appThemePalette
-
-    // Generate application light theme using KvColorPalette-Android light colors
-    val themeLight = lightColorScheme(
-        primary = theme.light.primary,
-        secondary = theme.light.secondary,
-        tertiary = theme.light.tertiary,
-        background = theme.light.background,
-        onPrimary = theme.light.onPrimary,
-        onSecondary = theme.light.onSecondary
-    )
-
-    // Generate application dark theme using KvColorPalette-Android dark colors
-    val themeDark = darkColorScheme(
-        primary = theme.dark.primary,
-        secondary = theme.dark.secondary,
-        tertiary = theme.dark.tertiary,
-        background = theme.dark.background,
-        onPrimary = theme.dark.onPrimary,
-        onSecondary = theme.dark.onSecondary
-    )
-    
     // Generate the color schema
     val appColorScheme = when {
-        darkTheme -> themeDark
-        else -> themeLight
+        darkTheme -> KvColorPalette.colorSchemeThemePalette.darkColorScheme
+        else -> KvColorPalette.colorSchemeThemePalette.lightColorScheme
     }
 
     // Assign the color schema to the team.

--- a/kv-color-palette/gradle.properties
+++ b/kv-color-palette/gradle.properties
@@ -1,3 +1,3 @@
 kvColorPaletteGroupId=com.github.KvColorPalette
 kvColorPaletteArtifactId=KvColorPalette-Android
-kvColorPaletteVersion=1.2.1
+kvColorPaletteVersion=2.0.0

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
@@ -29,6 +29,7 @@ class KvColorPalette {
          * provide a theme color palette. Consumer can use this as a singleton.
          */
         var instance: KvColorPalette = KvColorPalette()
+        @Deprecated("This field is deprecated. This is replaced by colorSchemeThemePalette")
         lateinit var appThemePalette: AppThemePalette
         lateinit var colorSchemeThemePalette: ColorSchemeThemePalette
 
@@ -159,14 +160,17 @@ class KvColorPalette {
      * @param givenColor The color to generate the theme color palette for.
      * @return A theme color palette.
      */
+    @Deprecated("This method is deprecated and replaced by generateThemeColorSchemePalette method", replaceWith = ReplaceWith(
+        "KvColorPalette.instance.generateThemeColorSchemePalette(givenColor = givenColor)"
+    ))
     fun generateThemeColorPalette(givenColor: Color): AppThemePalette = ThemeGenUtil.generateThemeColorSet(givenColor = givenColor)
 
     /**
      * Generate a theme color palette. According to the feeding color,
-     * this method generate a theme color palette.
+     * this method generate a color scheme theme color palette.
      *
      * @param givenColor The color to generate the theme color palette for.
-     * @return A theme color palette.
+     * @return A color scheme theme palette. [ColorSchemeThemePalette]
      */
     fun generateThemeColorSchemePalette(givenColor: Color): ColorSchemeThemePalette = ThemeGenUtil.generateThemeColorScheme(givenColor = givenColor)
 

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
@@ -13,6 +13,7 @@ import com.kavi.droid.color.palette.color.Mat900Package
 import com.kavi.droid.color.palette.color.MatPackage
 import com.kavi.droid.color.palette.extension.hsl
 import com.kavi.droid.color.palette.model.AppThemePalette
+import com.kavi.droid.color.palette.model.ColorSchemeThemePalette
 import com.kavi.droid.color.palette.model.KvColor
 import com.kavi.droid.color.palette.util.ColorUtil
 import com.kavi.droid.color.palette.util.ThemeGenUtil
@@ -29,6 +30,7 @@ class KvColorPalette {
          */
         var instance: KvColorPalette = KvColorPalette()
         lateinit var appThemePalette: AppThemePalette
+        lateinit var colorSchemeThemePalette: ColorSchemeThemePalette
 
         /**
          * KvColorPalette initialization. Consumer can use this to initialize the KvColorPalette from their application, if they need a
@@ -36,10 +38,13 @@ class KvColorPalette {
          *
          * On this initiation of KvColorPalette, we generate a theme color palette using the given color.
          * `basicColor` is mandatory parameter while initiate the library.
+         *
+         * @param basicColor: Color: Given color for generate theme palette.
          */
         fun initialize(basicColor: Color) {
-            val closestColor = ColorUtil.findClosestColor(basicColor)
-            appThemePalette = instance.generateThemeColorPalette(closestColor.color)
+            val closestColor = ColorUtil.findClosestColor(givenColor = basicColor)
+            appThemePalette = instance.generateThemeColorPalette(givenColor = closestColor.color)
+            colorSchemeThemePalette = instance.generateThemeColorSchemePalette(givenColor = closestColor.color)
         }
     }
 
@@ -48,6 +53,11 @@ class KvColorPalette {
          * This generate theme-palette with color transparent. This is un-usable.
          */
         appThemePalette = generateThemeColorPalette(Color.Transparent)
+
+        /**
+         * This generate theme-palette with color transparent. This is un-usable.
+         */
+        colorSchemeThemePalette = generateThemeColorSchemePalette(Color.Transparent)
     }
 
     /**
@@ -150,6 +160,15 @@ class KvColorPalette {
      * @return A theme color palette.
      */
     fun generateThemeColorPalette(givenColor: Color): AppThemePalette = ThemeGenUtil.generateThemeColorSet(givenColor = givenColor)
+
+    /**
+     * Generate a theme color palette. According to the feeding color,
+     * this method generate a theme color palette.
+     *
+     * @param givenColor The color to generate the theme color palette for.
+     * @return A theme color palette.
+     */
+    fun generateThemeColorSchemePalette(givenColor: Color): ColorSchemeThemePalette = ThemeGenUtil.generateThemeColorScheme(givenColor = givenColor)
 
     /**
      * This method finds the closest KvColor available in the KvColorPalette-Android to the given color

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/extension/Extension.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/extension/Extension.kt
@@ -3,6 +3,7 @@ package com.kavi.droid.color.palette.extension
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.graphics.ColorUtils
+import com.kavi.droid.color.palette.model.HSL
 
 /**
  * Extension function to get HSL properties of a [Color]
@@ -11,15 +12,6 @@ import androidx.core.graphics.ColorUtils
  */
 internal val Color.hsl: HSL
     get() = getHslProperties(this)
-
-/**
- * Data class to hold the hue, saturation and lightness properties of a [Color]
- */
-data class HSL(
-    val hue: Float,
-    val saturation: Float,
-    val lightness: Float
-)
 
 /**
  * This method extract and returns the hue, saturation and lightness properties of a [Color]

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/extension/OpenExtension.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/extension/OpenExtension.kt
@@ -1,5 +1,6 @@
 package com.kavi.droid.color.palette.extension
 
+import androidx.compose.material3.ColorScheme
 import androidx.compose.ui.graphics.Color
 
 /**
@@ -7,3 +8,19 @@ import androidx.compose.ui.graphics.Color
  */
 val Color.isHighLightColor: Boolean
     get() = this.hsl.lightness > 0.6f
+
+/**
+ * Providing new extension fields to [ColorScheme]
+ * @see base: Base color is the consumer provided color to generate the theme
+ * @see quaternary: Quaternary color is for the use of using primary color in light mode with contrast color in dark mode
+ * @see shadow: Shadow color is for the use of shadow in light mode and dark mode.
+ */
+var ColorScheme.base: Color
+    get() = Color.White
+    set(value) {}
+var ColorScheme.quaternary: Color
+    get() = Color.White
+    set(value) {}
+var ColorScheme.shadow: Color
+    get() = Color.White
+    set(value) {}

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/model/HSL.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/model/HSL.kt
@@ -1,0 +1,12 @@
+package com.kavi.droid.color.palette.model
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Data class to hold the hue, saturation and lightness properties of a [Color]
+ */
+data class HSL(
+    val hue: Float,
+    val saturation: Float,
+    val lightness: Float
+)

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/model/ThemeColorPalette.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/model/ThemeColorPalette.kt
@@ -1,5 +1,6 @@
 package com.kavi.droid.color.palette.model
 
+import androidx.compose.material3.ColorScheme
 import androidx.compose.ui.graphics.Color
 
 /**
@@ -8,6 +9,14 @@ import androidx.compose.ui.graphics.Color
 data class AppThemePalette(
     val light: ThemeColorPalette,
     val dark: ThemeColorPalette
+)
+
+/**
+ * Application [ColorScheme] theme palette for light and dark mode.
+ */
+data class ColorSchemeThemePalette(
+    val lightColorScheme: ColorScheme,
+    val darkColorScheme: ColorScheme
 )
 
 /**

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/model/ThemeColorPalette.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/model/ThemeColorPalette.kt
@@ -6,6 +6,9 @@ import androidx.compose.ui.graphics.Color
 /**
  * Application theme palette for light and dark mode.
  */
+@Deprecated(message = "This model is deprecated",
+    ReplaceWith("ColorSchemeThemePalette(lightColorScheme = lightScheme, darkColorScheme = darkScheme)")
+)
 data class AppThemePalette(
     val light: ThemeColorPalette,
     val dark: ThemeColorPalette

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
@@ -1,17 +1,48 @@
 package com.kavi.droid.color.palette.util
 
+import android.content.Context
+import android.content.res.Configuration
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
+import com.kavi.droid.color.palette.extension.base
 import com.kavi.droid.color.palette.extension.hsl
+import com.kavi.droid.color.palette.extension.quaternary
+import com.kavi.droid.color.palette.extension.shadow
 import com.kavi.droid.color.palette.model.AppThemePalette
+import com.kavi.droid.color.palette.model.ColorSchemeThemePalette
 import com.kavi.droid.color.palette.model.ThemeColorPalette
 
 object ThemeGenUtil {
+
+    /**
+     * This is to find out application is in dark mode or not.
+     *
+     * @param context: Context: Android context
+     * @return Boolean: Boolean value says application in dark mode or not.
+     */
+    fun isAppInNightMode(context: Context): Boolean {
+        return when (context.resources.configuration.uiMode.and(Configuration.UI_MODE_NIGHT_MASK)) {
+            Configuration.UI_MODE_NIGHT_YES -> {
+                true
+            }
+            Configuration.UI_MODE_NIGHT_NO,
+            Configuration.UI_MODE_NIGHT_UNDEFINED -> {
+                false
+            }
+            else -> {
+                false
+            }
+        }
+    }
 
     /**
      * Generate theme color set for given color.
      * @param givenColor The color to generate theme color set.
      * @return A theme color set. [AppThemePalette]
      */
+    @Deprecated("")
     internal fun generateThemeColorSet(givenColor: Color): AppThemePalette {
         val lightColorPalette = generateLightThemeColorSet(givenColor)
         val darkColorPalette = generateDarkThemeColorSet(givenColor)
@@ -20,10 +51,23 @@ object ThemeGenUtil {
     }
 
     /**
+     * Generate theme color set for given color.
+     * @param givenColor The color to generate theme color set.
+     * @return A theme color set. [ColorSchemeThemePalette]
+     */
+    internal fun generateThemeColorScheme(givenColor: Color): ColorSchemeThemePalette {
+        val lightColorPalette = generateThemeLightColorScheme(givenColor)
+        val darkColorPalette = generateThemeDarkColorScheme(givenColor)
+
+        return ColorSchemeThemePalette(lightColorScheme = lightColorPalette, darkColorScheme = darkColorPalette)
+    }
+
+    /**
      * Generate light theme color set for given color.
      * @param givenColor The color to generate theme color set.
      * @return A light theme color set. [ThemeColorPalette]
      */
+    @Deprecated("")
     private fun generateLightThemeColorSet(givenColor: Color): ThemeColorPalette {
         return ThemeColorPalette(
             base = givenColor,
@@ -39,10 +83,32 @@ object ThemeGenUtil {
     }
 
     /**
+     * Generate light theme color set for given color.
+     * @param givenColor The color to generate theme color set.
+     * @return A light theme color set. [ColorScheme]
+     */
+    private fun generateThemeLightColorScheme(givenColor: Color): ColorScheme {
+        val lightColorScheme = lightColorScheme(
+            primary = givenColor,
+            secondary = generateLightSecondaryColor(givenColor),
+            tertiary = generateLightTertiaryColor(givenColor),
+            background = generateLightBackgroundColor(givenColor),
+            onPrimary = Color.White,
+            onSecondary = Color.White
+        )
+        lightColorScheme.base = givenColor
+        lightColorScheme.quaternary = givenColor // This is for use light theme primary color dark theme contrast color
+        lightColorScheme.shadow = Color.Gray
+
+        return lightColorScheme
+    }
+
+    /**
      * Generate dark theme color set for given color.
      * @param givenColor he color to generate theme color set.
      * @return A dark theme color set. [ThemeColorPalette]
      */
+    @Deprecated("")
     private fun generateDarkThemeColorSet(givenColor: Color): ThemeColorPalette {
         return ThemeColorPalette(
             base = givenColor,
@@ -55,6 +121,28 @@ object ThemeGenUtil {
             onSecondary = Color.Black,
             shadow = Color.White
         )
+    }
+
+    /**
+     * Generate dark theme color set for given color.
+     * @param givenColor he color to generate theme color set.
+     * @return A dark theme color set. [ColorScheme]
+     */
+    private fun generateThemeDarkColorScheme(givenColor: Color): ColorScheme {
+        val darkColorScheme = darkColorScheme(
+            primary = generateDarkPrimaryColor(givenColor),
+            secondary = generateDarkSecondaryColor(givenColor),
+            tertiary = generateDarkTertiaryColor(givenColor),
+            background = generateDarkBackgroundColor(givenColor),
+            onPrimary = Color.White,
+            onSecondary = Color.Black,
+        )
+
+        darkColorScheme.base = givenColor
+        darkColorScheme.quaternary = generateDarkSecondaryColor(givenColor) // This is for use light theme primary color dark theme contrast color
+        darkColorScheme.shadow = Color.White
+
+        return darkColorScheme
     }
 
     /**

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
@@ -42,7 +42,10 @@ object ThemeGenUtil {
      * @param givenColor The color to generate theme color set.
      * @return A theme color set. [AppThemePalette]
      */
-    @Deprecated("")
+    @Deprecated(
+        message = "This method is deprecated and replaced by generateThemeColorScheme.",
+        replaceWith = ReplaceWith("ThemeGenUtil.generateThemeColorScheme(givenColor = givenColor)")
+    )
     internal fun generateThemeColorSet(givenColor: Color): AppThemePalette {
         val lightColorPalette = generateLightThemeColorSet(givenColor)
         val darkColorPalette = generateDarkThemeColorSet(givenColor)
@@ -67,7 +70,10 @@ object ThemeGenUtil {
      * @param givenColor The color to generate theme color set.
      * @return A light theme color set. [ThemeColorPalette]
      */
-    @Deprecated("")
+    @Deprecated(
+        message = "This method is deprecated and replaced by generateThemeLightColorScheme.",
+        replaceWith = ReplaceWith("ThemeGenUtil.generateThemeLightColorScheme(givenColor = givenColor)")
+    )
     private fun generateLightThemeColorSet(givenColor: Color): ThemeColorPalette {
         return ThemeColorPalette(
             base = givenColor,
@@ -108,7 +114,10 @@ object ThemeGenUtil {
      * @param givenColor he color to generate theme color set.
      * @return A dark theme color set. [ThemeColorPalette]
      */
-    @Deprecated("")
+    @Deprecated(
+        message = "This method is deprecated and replaced by generateThemeDarkColorScheme.",
+        replaceWith = ReplaceWith("ThemeGenUtil.generateThemeDarkColorScheme(givenColor = givenColor)")
+    )
     private fun generateDarkThemeColorSet(givenColor: Color): ThemeColorPalette {
         return ThemeColorPalette(
             base = givenColor,


### PR DESCRIPTION
# Theme color schema integration change
This change introduce new way to assign generated theme color schema to the application. While introducing new changes, deprecated the previous way of implementation and integration theme palette to consumer application.

#### commits:
* [Update the library version to 2.0.0](https://github.com/KvColorPalette/KvColorPalette-Android/commit/ee3c548b0d69aa91ae7bae5439789aa6e6612bcc)
* [Update the README.md for latest integration and usage changers](https://github.com/KvColorPalette/KvColorPalette-Android/commit/7d35d9d38a740bf1cfe441b27f8056ceea6342b2)
* [Marked older method as Deprecated and update the code comments.](https://github.com/KvColorPalette/KvColorPalette-Android/commit/bc31373d4f547cebf5e37f38babb683cccca61ad)
* [Export ColorScheme objects as theme palette to providing a theme to a…](https://github.com/KvColorPalette/KvColorPalette-Android/commit/41a3c89a8d019b1d1b6c300f2daafcf5023ea064)
* [Introduce new field extensions to ColorScheme](https://github.com/KvColorPalette/KvColorPalette-Android/commit/f7cb9c3aa87b0576fe102edbe8af1884c48e5753)
* [Move the HSL data model as a separate data class from extension file](https://github.com/KvColorPalette/KvColorPalette-Android/commit/6d477e56574fa394ca14418c3dc087d1ba258ec7)