### PR TITLE
Bugfix/color scheme extention fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Add the following dependency to your `build.gradle` / `build.gradle.kts` file:
 For Groovy - `build.gradle`:
 ````
 dependencies {
-    implementation 'com.github.KvColorPalette:KvColorPalette-Android:2.1.0'
+    implementation 'com.github.KvColorPalette:KvColorPalette-Android:2.1.1'
 }
 ````
 For Kotlin DSL - `build.gradle.kts`:
 ````
 dependencies {
-    implementation("com.github.KvColorPalette:KvColorPalette-Android:2.1.0")
+    implementation("com.github.KvColorPalette:KvColorPalette-Android:2.1.1")
 }
 ````
 
@@ -55,7 +55,7 @@ KvColorPalette.instance.generateLightnessColorPalette(givenColor = MatPackage().
 KvColorPalette.instance.generateSaturationColorPalette(givenColor = MatPackage().matGold.color)
 
 // Generate theme color palette of given color
-KvColorPalette.instance.generateThemeColorPalette(givenColor = MatPackage().matGold.color)
+KvColorPalette.instance.generateThemeColorSchemePalette(givenColor = MatPackage().matGold.color)
 ```
 
 ### Advance Usage

--- a/kv-color-palette/gradle.properties
+++ b/kv-color-palette/gradle.properties
@@ -1,3 +1,3 @@
 kvColorPaletteGroupId=com.github.KvColorPalette
 kvColorPaletteArtifactId=KvColorPalette-Android
-kvColorPaletteVersion=2.1.0
+kvColorPaletteVersion=2.1.1

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/extension/ColorExtension.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/extension/ColorExtension.kt
@@ -1,6 +1,5 @@
 package com.kavi.droid.color.palette.extension
 
-import androidx.compose.material3.ColorScheme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.graphics.ColorUtils
@@ -19,22 +18,6 @@ val Color.isHighLightColor: Boolean
  */
 val Color.hsl: HSL
     get() = getHslProperties(this)
-
-/**
- * Providing new extension fields to [ColorScheme]
- * @see base: Base color is the consumer provided color to generate the theme
- * @see quaternary: Quaternary color is for the use of using primary color in light mode with contrast color in dark mode
- * @see shadow: Shadow color is for the use of shadow in light mode and dark mode.
- */
-var ColorScheme.base: Color
-    get() = Color.White
-    set(value) {}
-var ColorScheme.quaternary: Color
-    get() = Color.White
-    set(value) {}
-var ColorScheme.shadow: Color
-    get() = Color.White
-    set(value) {}
 
 /**
  * This method extract and returns the hue, saturation and lightness properties of a [Color]

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/extension/ColorSchemeExtension.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/extension/ColorSchemeExtension.kt
@@ -1,0 +1,43 @@
+package com.kavi.droid.color.palette.extension
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.ui.graphics.Color
+import com.kavi.droid.color.palette.util.ThemeGenUtil
+import java.util.WeakHashMap
+
+/**
+ * Providing new extension fields to [ColorScheme]
+ * @see base: Base color is the consumer provided color to generate the theme
+ * @see quaternary: Quaternary color is for the use of using primary color in light mode with contrast color in dark mode
+ * @see shadow: Shadow color is for the use of shadow in light mode and dark mode.
+ */
+private val colorSchemeMap = WeakHashMap<String, Color>()
+
+// This is the base given color. This is gonna be same as provided color in light and dark modes.
+var ColorScheme.base: Color
+    get() = colorSchemeMap["base"] ?: Color.White
+    set(value) {
+        colorSchemeMap["base"] = value
+    }
+
+// This is for use light theme primary color dark theme contrast color
+val ColorScheme.quaternary: Color
+    get() = getQuaternaryColor(this)
+
+// This is for use the shadow color of a component
+val ColorScheme.shadow: Color
+    get() = getShadowColor(this)
+
+private fun getQuaternaryColor(colorScheme: ColorScheme): Color {
+    return if (colorScheme.background.isHighLightColor)
+        ThemeGenUtil.generateLightQuaternaryColor(colorScheme.base)
+    else
+        ThemeGenUtil.generateDarkQuaternaryColor(colorScheme.base)
+}
+
+private fun getShadowColor(colorScheme: ColorScheme): Color {
+    return if (colorScheme.background.isHighLightColor)
+        Color.Gray
+    else
+        Color.White
+}

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/extension/ColorSchemeExtension.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/extension/ColorSchemeExtension.kt
@@ -13,21 +13,35 @@ import java.util.WeakHashMap
  */
 private val colorSchemeMap = WeakHashMap<String, Color>()
 
-// This is the base given color. This is gonna be same as provided color in light and dark modes.
+/**
+ * This is the base given color. This is gonna be same as provided color in light and dark modes.
+ */
 var ColorScheme.base: Color
     get() = colorSchemeMap["base"] ?: Color.White
     set(value) {
         colorSchemeMap["base"] = value
     }
 
-// This is for use light theme primary color dark theme contrast color
+/**
+ * This is for use light theme primary color dark theme contrast color
+ */
 val ColorScheme.quaternary: Color
     get() = getQuaternaryColor(this)
 
-// This is for use the shadow color of a component
+/**
+ * This is for use the shadow color of a component
+ */
 val ColorScheme.shadow: Color
     get() = getShadowColor(this)
 
+/**
+ * This returns quaternary color according to the theme mode. This method finds the mode from the
+ * theme color scheme's background color. If the background color is a lighter one, it's assume
+ * this is light mode and generate the quaternary color.
+ *
+ * @param colorScheme: [ColorScheme] of the theme
+ * @return color: [Color] quaternary color for theme
+ */
 private fun getQuaternaryColor(colorScheme: ColorScheme): Color {
     return if (colorScheme.background.isHighLightColor)
         ThemeGenUtil.generateLightQuaternaryColor(colorScheme.base)
@@ -35,6 +49,14 @@ private fun getQuaternaryColor(colorScheme: ColorScheme): Color {
         ThemeGenUtil.generateDarkQuaternaryColor(colorScheme.base)
 }
 
+/**
+ * This returns shadow color according to the theme mode. This method finds the mode from the
+ * theme color scheme's background color. If the background color is a lighter one, it's assume
+ * this is light mode and returns the shadow color.
+ *
+ * @param colorScheme: [ColorScheme] of the theme
+ * @return color: [Color] shadow color for theme
+ */
 private fun getShadowColor(colorScheme: ColorScheme): Color {
     return if (colorScheme.background.isHighLightColor)
         Color.Gray

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
@@ -66,6 +66,22 @@ object ThemeGenUtil {
     }
 
     /**
+     * This method is generating quaternary color in the color theme palette for light mode. This is for internal use method
+     * @param givenColor: Color to generate light mode quaternary color
+     * @return Color
+     */
+    internal fun generateLightQuaternaryColor(givenColor: Color): Color =
+        givenColor
+
+    /**
+     * This method is generating quaternary color in the color theme palette for dark mode. This is for internal use method
+     * @param givenColor: Color to generate dark mode quaternary color
+     * @return Color
+     */
+    internal fun generateDarkQuaternaryColor(givenColor: Color): Color =
+        generateDarkSecondaryColor(givenColor)
+
+    /**
      * Generate light theme color set for given color.
      * @param givenColor The color to generate theme color set.
      * @return A light theme color set. [ThemeColorPalette]
@@ -103,8 +119,6 @@ object ThemeGenUtil {
             onSecondary = Color.White
         )
         lightColorScheme.base = givenColor
-        lightColorScheme.quaternary = givenColor // This is for use light theme primary color dark theme contrast color
-        lightColorScheme.shadow = Color.Gray
 
         return lightColorScheme
     }
@@ -148,8 +162,6 @@ object ThemeGenUtil {
         )
 
         darkColorScheme.base = givenColor
-        darkColorScheme.quaternary = generateDarkSecondaryColor(givenColor) // This is for use light theme primary color dark theme contrast color
-        darkColorScheme.shadow = Color.White
 
         return darkColorScheme
     }


### PR DESCRIPTION
# Bugfix
This is a bug fix to `KvColorPalette-Android` was fails to provide the additional generate quaternary and shadow color in `ColorScheme` object. This issue happen due to the wrong definition of kotlin extension.

#### Bug: https://github.com/KvColorPalette/KvColorPalette-Android/issues/18

#### commits:
* [Update the README.md](https://github.com/KvColorPalette/KvColorPalette-Android/commit/27cefdcadc30ccc97c3a7146a1a3b7bcff2b3903)
* [Separate the ColorScheme extension.](https://github.com/KvColorPalette/KvColorPalette-Android/commit/b3586f705ff1c852d4147706f1c8d87547c03ecc)

