### PR TITLE
Feature/pass color count for color palettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Add the following dependency to your `build.gradle` / `build.gradle.kts` file:
 For Groovy - `build.gradle`:
 ````
 dependencies {
-    implementation 'com.github.KvColorPalette:KvColorPalette-Android:2.1.1'
+    implementation 'com.github.KvColorPalette:KvColorPalette-Android:2.2.0'
 }
 ````
 For Kotlin DSL - `build.gradle.kts`:
 ````
 dependencies {
-    implementation("com.github.KvColorPalette:KvColorPalette-Android:2.1.1")
+    implementation("com.github.KvColorPalette:KvColorPalette-Android:2.2.0")
 }
 ````
 
@@ -46,13 +46,13 @@ If you wants to consume basic features in `KvColorPalette-Android` then use sing
 KvColorPalette.instance.generateColorPalette(givenColor = MatPackage().matGold)
 
 // Generate alpha color schem of given color
-KvColorPalette.instance.generateAlphaColorPalette(givenColor = MatPackage().matGold.color)
+KvColorPalette.instance.generateAlphaColorPalette(givenColor = MatPackage().matGold.color, colorCount = 8)
 
 // Generate lightness color schem of given color
-KvColorPalette.instance.generateLightnessColorPalette(givenColor = MatPackage().matGold.color)
+KvColorPalette.instance.generateLightnessColorPalette(givenColor = MatPackage().matGold.color, colorCount = 12)
 
 // Generate saturation color schem of given color
-KvColorPalette.instance.generateSaturationColorPalette(givenColor = MatPackage().matGold.color)
+KvColorPalette.instance.generateSaturationColorPalette(givenColor = MatPackage().matGold.color, colorCount = 15)
 
 // Generate theme color palette of given color
 KvColorPalette.instance.generateThemeColorSchemePalette(givenColor = MatPackage().matGold.color)

--- a/kv-color-palette/gradle.properties
+++ b/kv-color-palette/gradle.properties
@@ -1,3 +1,3 @@
 kvColorPaletteGroupId=com.github.KvColorPalette
 kvColorPaletteArtifactId=KvColorPalette-Android
-kvColorPaletteVersion=2.1.1
+kvColorPaletteVersion=2.2.0

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
@@ -70,19 +70,14 @@ class KvColorPalette {
      * This accept integer value in a range of 2 - 30. Even someone passes number more than 30, this will returns only 30 colors.
      * @return A list of colors.
      */
-    fun generateAlphaColorPalette(givenColor: Color, colorCount: Int = 10): List<Color> =
-        listOf(
-            Color(givenColor.red, givenColor.green, givenColor.blue, 1f),
-            Color(givenColor.red, givenColor.green, givenColor.blue, .9f),
-            Color(givenColor.red, givenColor.green, givenColor.blue, .8f),
-            Color(givenColor.red, givenColor.green, givenColor.blue, .7f),
-            Color(givenColor.red, givenColor.green, givenColor.blue, .6f),
-            Color(givenColor.red, givenColor.green, givenColor.blue, .5f),
-            Color(givenColor.red, givenColor.green, givenColor.blue, .4f),
-            Color(givenColor.red, givenColor.green, givenColor.blue, .3f),
-            Color(givenColor.red, givenColor.green, givenColor.blue, .2f),
-            Color(givenColor.red, givenColor.green, givenColor.blue, .1f),
-        )
+    fun generateAlphaColorPalette(givenColor: Color, colorCount: Int = 10): List<Color> {
+        val colorList = mutableListOf<Color>()
+        val reviseColorCount = ColorUtil.validateAndReviseColorCount(colorCount)
+        for (i in reviseColorCount downTo 1) {
+            colorList.add(Color(givenColor.red, givenColor.green, givenColor.blue, ((1f/colorCount)*i)))
+        }
+        return colorList
+    }
 
     /**
      * Generate a list of colors with color saturation values. According to the feeding color,

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
@@ -121,19 +121,6 @@ class KvColorPalette {
             colorList.add(Color.hsl(hue = hue, saturation = saturation, lightness = ((1f/colorCount)*i)))
         }
         return colorList
-
-        /*return listOf(
-            Color.hsl(hue = hue, saturation = saturation, lightness = 1f),
-            Color.hsl(hue = hue, saturation = saturation, lightness = 0.9f),
-            Color.hsl(hue = hue, saturation = saturation, lightness = 0.8f),
-            Color.hsl(hue = hue, saturation = saturation, lightness = 0.7f),
-            Color.hsl(hue = hue, saturation = saturation, lightness = 0.6f),
-            Color.hsl(hue = hue, saturation = saturation, lightness = 0.5f),
-            Color.hsl(hue = hue, saturation = saturation, lightness = 0.4f),
-            Color.hsl(hue = hue, saturation = saturation, lightness = 0.3f),
-            Color.hsl(hue = hue, saturation = saturation, lightness = 0.2f),
-            Color.hsl(hue = hue, saturation = saturation, lightness = 0.1f)
-        )*/
     }
 
     /**

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
@@ -92,18 +92,13 @@ class KvColorPalette {
         val hue = givenColor.hsl.hue
         val lightness = givenColor.hsl.lightness
 
-        return listOf(
-            Color.hsl(hue = hue, saturation = 1f, lightness = lightness),
-            Color.hsl(hue = hue, saturation = 0.9f, lightness = lightness),
-            Color.hsl(hue = hue, saturation = 0.8f, lightness = lightness),
-            Color.hsl(hue = hue, saturation = 0.7f, lightness = lightness),
-            Color.hsl(hue = hue, saturation = 0.6f, lightness = lightness),
-            Color.hsl(hue = hue, saturation = 0.5f, lightness = lightness),
-            Color.hsl(hue = hue, saturation = 0.4f, lightness = lightness),
-            Color.hsl(hue = hue, saturation = 0.3f, lightness = lightness),
-            Color.hsl(hue = hue, saturation = 0.2f, lightness = lightness),
-            Color.hsl(hue = hue, saturation = 0.1f, lightness = lightness)
-        )
+        val colorList = mutableListOf<Color>()
+        val reviseColorCount = ColorUtil.validateAndReviseColorCount(colorCount)
+
+        for (i in reviseColorCount downTo 1) {
+            colorList.add(Color.hsl(hue = hue, saturation = ((1f/colorCount)*i), lightness = lightness))
+        }
+        return colorList
     }
 
     /**

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
@@ -114,7 +114,15 @@ class KvColorPalette {
         val hue = givenColor.hsl.hue
         val saturation = givenColor.hsl.saturation
 
-        return listOf(
+        val colorList = mutableListOf<Color>()
+        val reviseColorCount = ColorUtil.validateAndReviseColorCount(colorCount)
+
+        for (i in reviseColorCount downTo 1) {
+            colorList.add(Color.hsl(hue = hue, saturation = saturation, lightness = ((1f/colorCount)*i)))
+        }
+        return colorList
+
+        /*return listOf(
             Color.hsl(hue = hue, saturation = saturation, lightness = 1f),
             Color.hsl(hue = hue, saturation = saturation, lightness = 0.9f),
             Color.hsl(hue = hue, saturation = saturation, lightness = 0.8f),
@@ -125,7 +133,7 @@ class KvColorPalette {
             Color.hsl(hue = hue, saturation = saturation, lightness = 0.3f),
             Color.hsl(hue = hue, saturation = saturation, lightness = 0.2f),
             Color.hsl(hue = hue, saturation = saturation, lightness = 0.1f)
-        )
+        )*/
     }
 
     /**

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
@@ -66,9 +66,11 @@ class KvColorPalette {
      * this method generate a list of colors with different alpha values.
      *
      * @param givenColor The color to generate the alpha values for.
+     * @param colorCount The number of colors to generate. In default that returns 10 colors.
+     * This accept integer value in a range of 2 - 30. Even someone passes number more than 30, this will returns only 30 colors.
      * @return A list of colors.
      */
-    fun generateAlphaColorPalette(givenColor: Color): List<Color> =
+    fun generateAlphaColorPalette(givenColor: Color, colorCount: Int = 10): List<Color> =
         listOf(
             Color(givenColor.red, givenColor.green, givenColor.blue, 1f),
             Color(givenColor.red, givenColor.green, givenColor.blue, .9f),
@@ -87,9 +89,11 @@ class KvColorPalette {
      * this method generate a list of color with different saturation values.
      *
      * @param givenColor The color to generate the saturation values for.
+     * @param colorCount The number of colors to generate. In default that returns 10 colors.
+     * This accept integer value in a range of 2 - 30. Even someone passes number more than 30, this will returns only 30 colors.
      * @return A list of colors.
      */
-    fun generateSaturationColorPalette(givenColor: Color): List<Color> {
+    fun generateSaturationColorPalette(givenColor: Color, colorCount: Int = 10): List<Color> {
         val hue = givenColor.hsl.hue
         val lightness = givenColor.hsl.lightness
 
@@ -112,9 +116,11 @@ class KvColorPalette {
      * this method generate a list of color with different lightness values.
      *
      * @param givenColor The color to generate the lightness values for.
+     * @param colorCount The number of colors to generate. In default that returns 10 colors.
+     * This accept integer value in a range of 2 - 30. Even someone passes number more than 30, this will returns only 30 colors.
      * @return A list of colors.
      */
-    fun generateLightnessColorPalette(givenColor: Color): List<Color> {
+    fun generateLightnessColorPalette(givenColor: Color, colorCount: Int = 10): List<Color> {
         val hue = givenColor.hsl.hue
         val saturation = givenColor.hsl.saturation
 

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ColorUtil.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ColorUtil.kt
@@ -120,4 +120,14 @@ object ColorUtil {
                 abs(colorOne.alpha - colorTwo.alpha)
 
     }
+
+    /**
+     * Validate the color count requested by the user in the color palette.
+     * If the color count is greater than 30, then it will return 30. If the color count is less than 1, then it will return 1.
+     *
+     * @param colorCount [Int] The number of colors to generate.
+     * @return Int: The validated color count.
+     */
+    internal fun validateAndReviseColorCount(colorCount: Int): Int =
+        if (colorCount >= 30) { 30 } else if (colorCount <= 1) { 1 } else { colorCount }
 }


### PR DESCRIPTION
# Color count for color palette
This change introduce a new parameter as `colorCount` to the APIs that generate color palette from color alpha, color saturation, color lightness properties. Consumer can provide integer value in rage of 1 - 30 and according to the number consumer provide it generate a number of colors in color palette. 

#### commits:
* [Update the README.md for new changes in APIs](https://github.com/KvColorPalette/KvColorPalette-Android/commit/6fc95e71674252295afeefe855ee18171458a858)
* [Generate the lightness color palette according to the color count pro…](https://github.com/KvColorPalette/KvColorPalette-Android/commit/c14441c22921165df4a5fef5a154ff42936e58ff)
* [Generate the saturation color palette according to the color count pr…](https://github.com/KvColorPalette/KvColorPalette-Android/commit/baa519737e427e72d10e88a34e665599ef1f0f43)
* [Generate the alpha color palette according to the color count provide…](https://github.com/KvColorPalette/KvColorPalette-Android/commit/9921d050c451d24445fb8843b06c264986ae12bb)
* [Add the parameter to color palette generation method to get the numbe…](https://github.com/KvColorPalette/KvColorPalette-Android/commit/635c3d8699f7983879a505839914a3426ca9ba4d)