### PR TITLE
Feature/accept secondary color to generate theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Add the following dependency to your `build.gradle` / `build.gradle.kts` file:
 For Groovy - `build.gradle`:
 ````
 dependencies {
-    implementation 'com.github.KvColorPalette:KvColorPalette-Android:2.2.0'
+    implementation 'com.github.KvColorPalette:KvColorPalette-Android:3.0.0'
 }
 ````
 For Kotlin DSL - `build.gradle.kts`:
 ````
 dependencies {
-    implementation("com.github.KvColorPalette:KvColorPalette-Android:2.2.0")
+    implementation("com.github.KvColorPalette:KvColorPalette-Android:3.0.0")
 }
 ````
 
@@ -60,12 +60,27 @@ KvColorPalette.instance.generateThemeColorSchemePalette(givenColor = MatPackage(
 
 ### Advance Usage
 If you wants to use `KvColorPalette-Android` to generate your theme color palette when your application start-up, then you have to initiate the library in Application level.
-To initiate you have to pass one base color that you think your application will use. Use following code to initiate the library package.
+There are two ways to initiate the library. These two methods for two different scenarios. First is to initiate the library with one base color and other is to initiate the library with two base colors.
+In two color method, there are additional parameters like `bias` and `themeGenPattern`.
+If your application styling with one base color then you can use following method to initialized,
 ````
 override fun onCreate() {
     super.onCreate()
     // Initialize the KvColorPalette-Android
-    KvColorPalette.initialize(Color.blue)
+    KvColorPalette.initialize(baseColor = Color.blue)
+}
+````
+If your application has two base colors, then you can use following method to initialized,
+````
+override fun onCreate() {
+    super.onCreate()
+    // Initialize the KvColorPalette-Android
+    KvColorPalette.initialize(
+        baseColor = Color.blue, 
+        secondColor = Color.red, 
+        themeGenPattern = ThemeGenMode.BLEND // The way to generate the theme palette using two colors.
+        bias = 0.5f, // How bias to first or second color
+    )
 }
 ````
 This initiation create a color schemas for a theme using the given color at the initiation. This generated color schemas will available for light and dark theme variants.

--- a/kv-color-palette/gradle.properties
+++ b/kv-color-palette/gradle.properties
@@ -1,3 +1,3 @@
 kvColorPaletteGroupId=com.github.KvColorPalette
 kvColorPaletteArtifactId=KvColorPalette-Android
-kvColorPaletteVersion=2.2.0
+kvColorPaletteVersion=3.0.0-SNAPSHOT

--- a/kv-color-palette/gradle.properties
+++ b/kv-color-palette/gradle.properties
@@ -1,3 +1,3 @@
 kvColorPaletteGroupId=com.github.KvColorPalette
 kvColorPaletteArtifactId=KvColorPalette-Android
-kvColorPaletteVersion=3.0.0-SNAPSHOT
+kvColorPaletteVersion=3.0.0

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
@@ -14,6 +14,7 @@ import com.kavi.droid.color.palette.color.MatPackage
 import com.kavi.droid.color.palette.extension.hsl
 import com.kavi.droid.color.palette.model.ColorSchemeThemePalette
 import com.kavi.droid.color.palette.model.KvColor
+import com.kavi.droid.color.palette.model.ThemeGenPattern
 import com.kavi.droid.color.palette.util.ColorUtil
 import com.kavi.droid.color.palette.util.ThemeGenUtil
 
@@ -142,8 +143,21 @@ class KvColorPalette {
      * @param givenColor The color to generate the theme color palette for.
      * @return A color scheme theme palette. [ColorSchemeThemePalette]
      */
-    fun generateThemeColorSchemePalette(givenColor: Color): ColorSchemeThemePalette = ThemeGenUtil.generateThemeColorScheme(givenColor = givenColor)
+    fun generateThemeColorSchemePalette(givenColor: Color): ColorSchemeThemePalette = ThemeGenUtil.singleColorThemeColorScheme(givenColor = givenColor)
 
+    /**
+     * Generate a theme color palette. According to the feeding color,
+     * this method generate a color scheme theme color palette.
+     *
+     * @param givenColor The color to generate the theme color palette for.
+     * @param secondColor The secondary color to generate the theme color palette blending with first color.
+     * @param bias The bias value to blend the two colors. In default that is 0.5f. This accept float value in a range of 0.0 - 1.0.
+     * 0f means full bias to first color and 1f means full bias to second color.
+     * @return A color scheme theme palette. [ColorSchemeThemePalette]
+     */
+    fun generateMultiColorThemeColorSchemePalette(givenColor: Color, secondColor: Color, bias: Float = .5f, themeGenPattern: ThemeGenPattern = ThemeGenPattern.SEQUENCE): ColorSchemeThemePalette {
+        return ThemeGenUtil.multiColorInputThemeColorScheme(givenColor = givenColor, secondColor = secondColor, bias = bias, themeGenPattern = themeGenPattern)
+    }
     /**
      * This method finds the closest KvColor available in the KvColorPalette-Android to the given color
      *

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
@@ -14,7 +14,7 @@ import com.kavi.droid.color.palette.color.MatPackage
 import com.kavi.droid.color.palette.extension.hsl
 import com.kavi.droid.color.palette.model.ColorSchemeThemePalette
 import com.kavi.droid.color.palette.model.KvColor
-import com.kavi.droid.color.palette.model.ThemeGenPattern
+import com.kavi.droid.color.palette.model.ThemeGenMode
 import com.kavi.droid.color.palette.util.ColorUtil
 import com.kavi.droid.color.palette.util.ThemeGenUtil
 
@@ -41,8 +41,7 @@ class KvColorPalette {
          * @param baseColor: Color: Given color for generate theme palette.
          */
         fun initialize(baseColor: Color) {
-            val closestColor = ColorUtil.findClosestColor(givenColor = baseColor)
-            colorSchemeThemePalette = instance.generateThemeColorSchemePalette(givenColor = closestColor.color)
+            colorSchemeThemePalette = instance.generateThemeColorSchemePalette(givenColor = baseColor)
         }
 
         /**
@@ -56,17 +55,17 @@ class KvColorPalette {
          * @param secondColor: Color: Given second color for generate theme palette.
          * @param bias: Float: The bias value to blend the two colors. In default that is 0.5f. This accept float value in a range of 0.0 - 1.0.
          * 0f means full bias to first color and 1f means full bias to second color.
-         * @param themeGenPattern: ThemeGenPattern: The pattern to generate the theme color palette.
-         * Default is [ThemeGenPattern.SEQUENCE] and available options are [ThemeGenPattern.SEQUENCE] and [ThemeGenPattern.BLEND]
-         * - [ThemeGenPattern.SEQUENCE] will add base color & primary & second color as secondary, rest of the colors will generate by using given base color.
-         * - [ThemeGenPattern.BLEND] will add base color & primary & second color as primary, rest of the colors will generate by after generating new color blend first and second colors.
+         * @param themeGenMode: ThemeGenPattern: The pattern to generate the theme color palette.
+         * Default is [ThemeGenMode.SEQUENCE] and available options are [ThemeGenMode.SEQUENCE] and [ThemeGenMode.BLEND]
+         * - [ThemeGenMode.SEQUENCE] will add base color & primary & second color as secondary, rest of the colors will generate by using given base color.
+         * - [ThemeGenMode.BLEND] will add base color & primary & second color as primary, rest of the colors will generate by after generating new color blend first and second colors.
          */
-        fun initialize(baseColor: Color, secondColor: Color, bias: Float = .5f, themeGenPattern: ThemeGenPattern = ThemeGenPattern.SEQUENCE) {
+        fun initialize(baseColor: Color, secondColor: Color, bias: Float = .5f, themeGenMode: ThemeGenMode = ThemeGenMode.SEQUENCE) {
             colorSchemeThemePalette = instance.generateMultiColorThemeColorSchemePalette(
                 givenColor = baseColor,
                 secondColor = secondColor,
                 bias = bias,
-                themeGenPattern = themeGenPattern
+                themeGenMode = themeGenMode
             )
         }
     }
@@ -178,14 +177,14 @@ class KvColorPalette {
      * @param secondColor The secondary color to generate the theme color palette blending with first color.
      * @param bias The bias value to blend the two colors. In default that is 0.5f. This accept float value in a range of 0.0 - 1.0.
      * 0f means full bias to first color and 1f means full bias to second color.
-     * @param themeGenPattern: ThemeGenPattern: The pattern to generate the theme color palette.
-     * Default is [ThemeGenPattern.SEQUENCE] and available options are [ThemeGenPattern.SEQUENCE] and [ThemeGenPattern.BLEND]
-     * - [ThemeGenPattern.SEQUENCE] will add base color & primary & second color as secondary, rest of the colors will generate by using given base color.
-     * - [ThemeGenPattern.BLEND] will add base color & primary & second color as primary, rest of the colors will generate by after generating new color blend first and second colors.
+     * @param themeGenMode: ThemeGenPattern: The pattern to generate the theme color palette.
+     * Default is [ThemeGenMode.SEQUENCE] and available options are [ThemeGenMode.SEQUENCE] and [ThemeGenMode.BLEND]
+     * - [ThemeGenMode.SEQUENCE] will add base color & primary & second color as secondary, rest of the colors will generate by using given base color.
+     * - [ThemeGenMode.BLEND] will add base color & primary & second color as primary, rest of the colors will generate by after generating new color blend first and second colors.
      * @return A color scheme theme palette. [ColorSchemeThemePalette]
      */
-    fun generateMultiColorThemeColorSchemePalette(givenColor: Color, secondColor: Color, bias: Float = .5f, themeGenPattern: ThemeGenPattern = ThemeGenPattern.SEQUENCE): ColorSchemeThemePalette {
-        return ThemeGenUtil.multiColorInputThemeColorScheme(givenColor = givenColor, secondColor = secondColor, bias = bias, themeGenPattern = themeGenPattern)
+    fun generateMultiColorThemeColorSchemePalette(givenColor: Color, secondColor: Color, bias: Float = .5f, themeGenMode: ThemeGenMode = ThemeGenMode.SEQUENCE): ColorSchemeThemePalette {
+        return ThemeGenUtil.multiColorInputThemeColorScheme(givenColor = givenColor, secondColor = secondColor, bias = bias, themeGenMode = themeGenMode)
     }
     /**
      * This method finds the closest KvColor available in the KvColorPalette-Android to the given color

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
@@ -35,7 +35,7 @@ class KvColorPalette {
          * KvColorPalette initialization. Consumer can use this to initialize the KvColorPalette from their application, if they need a
          * Theme color palette at the application start-up.
          *
-         * On this initiation of KvColorPalette, we generate a theme color palette using the given color.
+         * On this initiation of KvColorPalette, library generate a theme color palette using the given color.
          * `baseColor` is mandatory parameter while initiate the library.
          *
          * @param baseColor: Color: Given color for generate theme palette.
@@ -45,6 +45,22 @@ class KvColorPalette {
             colorSchemeThemePalette = instance.generateThemeColorSchemePalette(givenColor = closestColor.color)
         }
 
+        /**
+         * KvColorPalette initialization. Consumer can use this to initialize the KvColorPalette from their application, if they need a
+         * Theme color palette at the application start-up.
+         *
+         * On this initiation of KvColorPalette, library generate a theme color palette using the given base color and second color.
+         * `baseColor` and `secondColor` are mandatory parameter while initiate the library. Other two parameters are optional.
+         *
+         * @param baseColor: Color: Given first for generate theme palette.
+         * @param secondColor: Color: Given second color for generate theme palette.
+         * @param bias: Float: The bias value to blend the two colors. In default that is 0.5f. This accept float value in a range of 0.0 - 1.0.
+         * 0f means full bias to first color and 1f means full bias to second color.
+         * @param themeGenPattern: ThemeGenPattern: The pattern to generate the theme color palette.
+         * Default is [ThemeGenPattern.SEQUENCE] and available options are [ThemeGenPattern.SEQUENCE] and [ThemeGenPattern.BLEND]
+         * - [ThemeGenPattern.SEQUENCE] will add base color & primary & second color as secondary, rest of the colors will generate by using given base color.
+         * - [ThemeGenPattern.BLEND] will add base color & primary & second color as primary, rest of the colors will generate by after generating new color blend first and second colors.
+         */
         fun initialize(baseColor: Color, secondColor: Color, bias: Float = .5f, themeGenPattern: ThemeGenPattern = ThemeGenPattern.SEQUENCE) {
             colorSchemeThemePalette = instance.generateMultiColorThemeColorSchemePalette(
                 givenColor = baseColor,
@@ -162,6 +178,10 @@ class KvColorPalette {
      * @param secondColor The secondary color to generate the theme color palette blending with first color.
      * @param bias The bias value to blend the two colors. In default that is 0.5f. This accept float value in a range of 0.0 - 1.0.
      * 0f means full bias to first color and 1f means full bias to second color.
+     * @param themeGenPattern: ThemeGenPattern: The pattern to generate the theme color palette.
+     * Default is [ThemeGenPattern.SEQUENCE] and available options are [ThemeGenPattern.SEQUENCE] and [ThemeGenPattern.BLEND]
+     * - [ThemeGenPattern.SEQUENCE] will add base color & primary & second color as secondary, rest of the colors will generate by using given base color.
+     * - [ThemeGenPattern.BLEND] will add base color & primary & second color as primary, rest of the colors will generate by after generating new color blend first and second colors.
      * @return A color scheme theme palette. [ColorSchemeThemePalette]
      */
     fun generateMultiColorThemeColorSchemePalette(givenColor: Color, secondColor: Color, bias: Float = .5f, themeGenPattern: ThemeGenPattern = ThemeGenPattern.SEQUENCE): ColorSchemeThemePalette {

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
@@ -12,7 +12,6 @@ import com.kavi.droid.color.palette.color.Mat800Package
 import com.kavi.droid.color.palette.color.Mat900Package
 import com.kavi.droid.color.palette.color.MatPackage
 import com.kavi.droid.color.palette.extension.hsl
-import com.kavi.droid.color.palette.model.AppThemePalette
 import com.kavi.droid.color.palette.model.ColorSchemeThemePalette
 import com.kavi.droid.color.palette.model.KvColor
 import com.kavi.droid.color.palette.util.ColorUtil
@@ -29,8 +28,6 @@ class KvColorPalette {
          * provide a theme color palette. Consumer can use this as a singleton.
          */
         var instance: KvColorPalette = KvColorPalette()
-        @Deprecated("This field is deprecated. This is replaced by colorSchemeThemePalette")
-        lateinit var appThemePalette: AppThemePalette
         lateinit var colorSchemeThemePalette: ColorSchemeThemePalette
 
         /**
@@ -44,17 +41,11 @@ class KvColorPalette {
          */
         fun initialize(basicColor: Color) {
             val closestColor = ColorUtil.findClosestColor(givenColor = basicColor)
-            appThemePalette = instance.generateThemeColorPalette(givenColor = closestColor.color)
             colorSchemeThemePalette = instance.generateThemeColorSchemePalette(givenColor = closestColor.color)
         }
     }
 
     init {
-        /**
-         * This generate theme-palette with color transparent. This is un-usable.
-         */
-        appThemePalette = generateThemeColorPalette(Color.Transparent)
-
         /**
          * This generate theme-palette with color transparent. This is un-usable.
          */
@@ -143,18 +134,6 @@ class KvColorPalette {
             Mat100Package.getColor(colorName = givenColor.colorName).alphaChange(alphaChange).color,
             Mat50Package.getColor(colorName = givenColor.colorName).alphaChange(alphaChange).color
         )
-
-    /**
-     * Generate a theme color palette. According to the feeding color,
-     * this method generate a theme color palette.
-     *
-     * @param givenColor The color to generate the theme color palette for.
-     * @return A theme color palette.
-     */
-    @Deprecated("This method is deprecated and replaced by generateThemeColorSchemePalette method", replaceWith = ReplaceWith(
-        "KvColorPalette.instance.generateThemeColorSchemePalette(givenColor = givenColor)"
-    ))
-    fun generateThemeColorPalette(givenColor: Color): AppThemePalette = ThemeGenUtil.generateThemeColorSet(givenColor = givenColor)
 
     /**
      * Generate a theme color palette. According to the feeding color,

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/KvColorPalette.kt
@@ -36,13 +36,22 @@ class KvColorPalette {
          * Theme color palette at the application start-up.
          *
          * On this initiation of KvColorPalette, we generate a theme color palette using the given color.
-         * `basicColor` is mandatory parameter while initiate the library.
+         * `baseColor` is mandatory parameter while initiate the library.
          *
-         * @param basicColor: Color: Given color for generate theme palette.
+         * @param baseColor: Color: Given color for generate theme palette.
          */
-        fun initialize(basicColor: Color) {
-            val closestColor = ColorUtil.findClosestColor(givenColor = basicColor)
+        fun initialize(baseColor: Color) {
+            val closestColor = ColorUtil.findClosestColor(givenColor = baseColor)
             colorSchemeThemePalette = instance.generateThemeColorSchemePalette(givenColor = closestColor.color)
+        }
+
+        fun initialize(baseColor: Color, secondColor: Color, bias: Float = .5f, themeGenPattern: ThemeGenPattern = ThemeGenPattern.SEQUENCE) {
+            colorSchemeThemePalette = instance.generateMultiColorThemeColorSchemePalette(
+                givenColor = baseColor,
+                secondColor = secondColor,
+                bias = bias,
+                themeGenPattern = themeGenPattern
+            )
         }
     }
 

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/model/ThemeColorPalette.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/model/ThemeColorPalette.kt
@@ -4,17 +4,6 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.ui.graphics.Color
 
 /**
- * Application theme palette for light and dark mode.
- */
-@Deprecated(message = "This model is deprecated",
-    ReplaceWith("ColorSchemeThemePalette(lightColorScheme = lightScheme, darkColorScheme = darkScheme)")
-)
-data class AppThemePalette(
-    val light: ThemeColorPalette,
-    val dark: ThemeColorPalette
-)
-
-/**
  * Application [ColorScheme] theme palette for light and dark mode.
  */
 data class ColorSchemeThemePalette(

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/model/ThemeGenMode.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/model/ThemeGenMode.kt
@@ -1,5 +1,5 @@
 package com.kavi.droid.color.palette.model
 
-enum class ThemeGenPattern {
+enum class ThemeGenMode {
     SEQUENCE, BLEND
 }

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/model/ThemeGenPattern.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/model/ThemeGenPattern.kt
@@ -1,0 +1,5 @@
+package com.kavi.droid.color.palette.model
+
+enum class ThemeGenPattern {
+    SEQUENCE, BLEND
+}

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ColorUtil.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ColorUtil.kt
@@ -52,6 +52,22 @@ object ColorUtil {
     }
 
     /**
+     * This method is to blend given two colors and return new color
+     *
+     * @param firstColor [Color] First color to blend
+     * @param secondColor [Color] Second color to blend
+     * @param bias [Float] Bias to the new color for first / second color.
+     */
+    internal fun blendColors(firstColor: Color, secondColor: Color, bias: Float = 0.5f): Color {
+        val blendRed = ((firstColor.red * 255) + (secondColor.red * 255)) * (1f - bias)
+        val blendGreen = ((firstColor.green * 255) + (secondColor.green * 255)) * (1f - bias)
+        val blendBlue = ((firstColor.blue * 255) + (secondColor.blue * 255)) * (1f - bias)
+        //val blendAlpha = (firstColor.alpha + secondColor.alpha) * bias
+
+        return Color(blendRed / 255, blendGreen / 255, blendBlue / 255)
+    }
+
+    /**
      * Get closest color to the given color from available color packages.
      * This compares the available colors and find out the closest `KvColor` to the given color.
      *

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ColorUtil.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ColorUtil.kt
@@ -59,9 +59,9 @@ object ColorUtil {
      * @param bias [Float] Bias to the new color for first / second color.
      */
     internal fun blendColors(firstColor: Color, secondColor: Color, bias: Float = 0.5f): Color {
-        val blendRed = ((firstColor.red * 255) + (secondColor.red * 255)) * (1f - bias)
-        val blendGreen = ((firstColor.green * 255) + (secondColor.green * 255)) * (1f - bias)
-        val blendBlue = ((firstColor.blue * 255) + (secondColor.blue * 255)) * (1f - bias)
+        val blendRed = colorBlendingComponent(firstColor.red, secondColor.red, bias)
+        val blendGreen = colorBlendingComponent(firstColor.green, secondColor.green, bias)
+        val blendBlue = colorBlendingComponent(firstColor.blue, secondColor.blue, bias)
 
         return Color(blendRed / 255, blendGreen / 255, blendBlue / 255)
     }
@@ -145,4 +145,26 @@ object ColorUtil {
      */
     internal fun validateAndReviseColorCount(colorCount: Int): Int =
         if (colorCount >= 30) { 30 } else if (colorCount <= 1) { 1 } else { colorCount }
+
+    /**
+     * This method can return the color value of red/green/blue according to the blending bias
+     * with given first color's red/green/blue value and second color's red/green/blue value.
+     *
+     * @param firstColor The first color's red/green/blue value
+     * @param secondColor The second color's red/green/blue value
+     * @param bias The blending bias value.
+     *
+     */
+    private fun colorBlendingComponent(firstColor: Float, secondColor: Float, bias: Float): Float {
+        val difference = abs(firstColor * 255 - secondColor * 255)
+        val blending = difference * bias // How bias to the blending colors, first or second
+
+        return if (firstColor < secondColor) {
+            (firstColor * 255) + blending // First color is in lower end, therefore adding bias
+        } else if (firstColor > secondColor) {
+            (firstColor * 255) - blending // First color is in higher end, therefore subtracting bias
+        } else {
+            (firstColor * 255) // This means, first component and second component are same. Therefore, returns same value.
+        }
+    }
 }

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ColorUtil.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ColorUtil.kt
@@ -62,7 +62,6 @@ object ColorUtil {
         val blendRed = ((firstColor.red * 255) + (secondColor.red * 255)) * (1f - bias)
         val blendGreen = ((firstColor.green * 255) + (secondColor.green * 255)) * (1f - bias)
         val blendBlue = ((firstColor.blue * 255) + (secondColor.blue * 255)) * (1f - bias)
-        //val blendAlpha = (firstColor.alpha + secondColor.alpha) * bias
 
         return Color(blendRed / 255, blendGreen / 255, blendBlue / 255)
     }

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
@@ -8,11 +8,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
 import com.kavi.droid.color.palette.extension.base
 import com.kavi.droid.color.palette.extension.hsl
-import com.kavi.droid.color.palette.extension.quaternary
-import com.kavi.droid.color.palette.extension.shadow
-import com.kavi.droid.color.palette.model.AppThemePalette
 import com.kavi.droid.color.palette.model.ColorSchemeThemePalette
-import com.kavi.droid.color.palette.model.ThemeColorPalette
 
 object ThemeGenUtil {
 
@@ -35,22 +31,6 @@ object ThemeGenUtil {
                 false
             }
         }
-    }
-
-    /**
-     * Generate theme color set for given color.
-     * @param givenColor The color to generate theme color set.
-     * @return A theme color set. [AppThemePalette]
-     */
-    @Deprecated(
-        message = "This method is deprecated and replaced by generateThemeColorScheme.",
-        replaceWith = ReplaceWith("ThemeGenUtil.generateThemeColorScheme(givenColor = givenColor)")
-    )
-    internal fun generateThemeColorSet(givenColor: Color): AppThemePalette {
-        val lightColorPalette = generateLightThemeColorSet(givenColor)
-        val darkColorPalette = generateDarkThemeColorSet(givenColor)
-
-        return AppThemePalette(light = lightColorPalette, dark = darkColorPalette)
     }
 
     /**
@@ -84,29 +64,6 @@ object ThemeGenUtil {
     /**
      * Generate light theme color set for given color.
      * @param givenColor The color to generate theme color set.
-     * @return A light theme color set. [ThemeColorPalette]
-     */
-    @Deprecated(
-        message = "This method is deprecated and replaced by generateThemeLightColorScheme.",
-        replaceWith = ReplaceWith("ThemeGenUtil.generateThemeLightColorScheme(givenColor = givenColor)")
-    )
-    private fun generateLightThemeColorSet(givenColor: Color): ThemeColorPalette {
-        return ThemeColorPalette(
-            base = givenColor,
-            primary = givenColor,
-            secondary = generateLightSecondaryColor(givenColor),
-            tertiary = generateLightTertiaryColor(givenColor),
-            quaternary = givenColor, // This is for use light theme primary color dark theme contrast color
-            background = generateLightBackgroundColor(givenColor),
-            onPrimary = Color.White,
-            onSecondary = Color.White,
-            shadow = Color.Gray
-        )
-    }
-
-    /**
-     * Generate light theme color set for given color.
-     * @param givenColor The color to generate theme color set.
      * @return A light theme color set. [ColorScheme]
      */
     private fun generateThemeLightColorScheme(givenColor: Color): ColorScheme {
@@ -121,29 +78,6 @@ object ThemeGenUtil {
         lightColorScheme.base = givenColor
 
         return lightColorScheme
-    }
-
-    /**
-     * Generate dark theme color set for given color.
-     * @param givenColor he color to generate theme color set.
-     * @return A dark theme color set. [ThemeColorPalette]
-     */
-    @Deprecated(
-        message = "This method is deprecated and replaced by generateThemeDarkColorScheme.",
-        replaceWith = ReplaceWith("ThemeGenUtil.generateThemeDarkColorScheme(givenColor = givenColor)")
-    )
-    private fun generateDarkThemeColorSet(givenColor: Color): ThemeColorPalette {
-        return ThemeColorPalette(
-            base = givenColor,
-            primary = generateDarkPrimaryColor(givenColor),
-            secondary = generateDarkSecondaryColor(givenColor),
-            tertiary = generateDarkTertiaryColor(givenColor),
-            quaternary = generateDarkSecondaryColor(givenColor), // This is for use light theme primary color dark theme contrast color
-            background = generateDarkBackgroundColor(givenColor),
-            onPrimary = Color.White,
-            onSecondary = Color.Black,
-            shadow = Color.White
-        )
     }
 
     /**

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
@@ -46,6 +46,20 @@ object ThemeGenUtil {
         return ColorSchemeThemePalette(lightColorScheme = lightColorPalette, darkColorScheme = darkColorPalette)
     }
 
+    /**
+     * Generate a theme color palette. According to the feeding color,
+     * this method generate a color scheme theme color palette.
+     *
+     * @param givenColor The color to generate the theme color palette for.
+     * @param secondColor The secondary color to generate the theme color palette blending with first color.
+     * @param bias The bias value to blend the two colors. In default that is 0.5f. This accept float value in a range of 0.0 - 1.0.
+     * 0f means full bias to first color and 1f means full bias to second color.
+     * @param themeGenPattern: ThemeGenPattern: The pattern to generate the theme color palette.
+     * Default is [ThemeGenPattern.SEQUENCE] and available options are [ThemeGenPattern.SEQUENCE] and [ThemeGenPattern.BLEND]
+     * - [ThemeGenPattern.SEQUENCE] will add base color & primary & second color as secondary, rest of the colors will generate by using given base color.
+     * - [ThemeGenPattern.BLEND] will add base color & primary & second color as primary, rest of the colors will generate by after generating new color blend first and second colors.
+     * @return A color scheme theme palette. [ColorSchemeThemePalette]
+     */
     internal fun multiColorInputThemeColorScheme(givenColor: Color, secondColor: Color, bias: Float = 0.5f, themeGenPattern: ThemeGenPattern = ThemeGenPattern.SEQUENCE): ColorSchemeThemePalette {
         var blendColor: Color? = null
 
@@ -95,6 +109,13 @@ object ThemeGenUtil {
         return lightColorScheme
     }
 
+    /**
+     * Generate light theme color set for given colors.
+     * @param givenColor The color to generate the theme color palette for.
+     * @param secondColor The secondary color to generate the theme color palette blending with first color.
+     * @param themeGenPattern: ThemeGenPattern: The pattern to generate the theme color palette.
+     * @return A light theme color set. [ColorScheme]
+     */
     private fun generateMultiInputThemeLightColorScheme(givenColor: Color, secondColor: Color, blendColor: Color? = null, themeGenPattern: ThemeGenPattern = ThemeGenPattern.SEQUENCE): ColorScheme {
         when (themeGenPattern) {
             ThemeGenPattern.SEQUENCE -> {
@@ -147,6 +168,13 @@ object ThemeGenUtil {
         return darkColorScheme
     }
 
+    /**
+     * Generate dark theme color set for given color.
+     * @param givenColor The color to generate the theme color palette for.
+     * @param secondColor The secondary color to generate the theme color palette blending with first color.
+     * @param themeGenPattern: ThemeGenPattern: The pattern to generate the theme color palette.
+     * @return A dark theme color set. [ColorScheme]
+     */
     private fun generateMultiInputThemeDarkColorScheme(givenColor: Color, secondColor: Color, blendColor: Color? = null, themeGenPattern: ThemeGenPattern = ThemeGenPattern.SEQUENCE): ColorScheme {
         when (themeGenPattern) {
             ThemeGenPattern.SEQUENCE -> {

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.graphics.Color
 import com.kavi.droid.color.palette.extension.base
 import com.kavi.droid.color.palette.extension.hsl
 import com.kavi.droid.color.palette.model.ColorSchemeThemePalette
-import com.kavi.droid.color.palette.model.ThemeGenPattern
+import com.kavi.droid.color.palette.model.ThemeGenMode
 
 object ThemeGenUtil {
 
@@ -54,22 +54,22 @@ object ThemeGenUtil {
      * @param secondColor The secondary color to generate the theme color palette blending with first color.
      * @param bias The bias value to blend the two colors. In default that is 0.5f. This accept float value in a range of 0.0 - 1.0.
      * 0f means full bias to first color and 1f means full bias to second color.
-     * @param themeGenPattern: ThemeGenPattern: The pattern to generate the theme color palette.
-     * Default is [ThemeGenPattern.SEQUENCE] and available options are [ThemeGenPattern.SEQUENCE] and [ThemeGenPattern.BLEND]
-     * - [ThemeGenPattern.SEQUENCE] will add base color & primary & second color as secondary, rest of the colors will generate by using given base color.
-     * - [ThemeGenPattern.BLEND] will add base color & primary & second color as primary, rest of the colors will generate by after generating new color blend first and second colors.
+     * @param themeGenMode: ThemeGenPattern: The pattern to generate the theme color palette.
+     * Default is [ThemeGenMode.SEQUENCE] and available options are [ThemeGenMode.SEQUENCE] and [ThemeGenMode.BLEND]
+     * - [ThemeGenMode.SEQUENCE] will add base color & primary & second color as secondary, rest of the colors will generate by using given base color.
+     * - [ThemeGenMode.BLEND] will add base color & primary & second color as primary, rest of the colors will generate by after generating new color blend first and second colors.
      * @return A color scheme theme palette. [ColorSchemeThemePalette]
      */
-    internal fun multiColorInputThemeColorScheme(givenColor: Color, secondColor: Color, bias: Float = 0.5f, themeGenPattern: ThemeGenPattern = ThemeGenPattern.SEQUENCE): ColorSchemeThemePalette {
+    internal fun multiColorInputThemeColorScheme(givenColor: Color, secondColor: Color, bias: Float = 0.5f, themeGenMode: ThemeGenMode = ThemeGenMode.SEQUENCE): ColorSchemeThemePalette {
         var blendColor: Color? = null
 
-        blendColor = when (themeGenPattern) {
-            ThemeGenPattern.SEQUENCE -> { null }
-            ThemeGenPattern.BLEND -> { ColorUtil.blendColors(firstColor = givenColor, secondColor = secondColor, bias = bias) }
+        blendColor = when (themeGenMode) {
+            ThemeGenMode.SEQUENCE -> { null }
+            ThemeGenMode.BLEND -> { ColorUtil.blendColors(firstColor = givenColor, secondColor = secondColor, bias = bias) }
         }
 
-        val lightColorPalette = generateMultiInputThemeLightColorScheme(givenColor = givenColor, secondColor = secondColor, blendColor = blendColor, themeGenPattern = themeGenPattern)
-        val darkColorPalette = generateMultiInputThemeDarkColorScheme(givenColor = givenColor, secondColor = secondColor, blendColor = blendColor, themeGenPattern = themeGenPattern)
+        val lightColorPalette = generateMultiInputThemeLightColorScheme(givenColor = givenColor, secondColor = secondColor, blendColor = blendColor, themeGenMode = themeGenMode)
+        val darkColorPalette = generateMultiInputThemeDarkColorScheme(givenColor = givenColor, secondColor = secondColor, blendColor = blendColor, themeGenMode = themeGenMode)
 
         return ColorSchemeThemePalette(lightColorScheme = lightColorPalette, darkColorScheme = darkColorPalette)
     }
@@ -113,12 +113,12 @@ object ThemeGenUtil {
      * Generate light theme color set for given colors.
      * @param givenColor The color to generate the theme color palette for.
      * @param secondColor The secondary color to generate the theme color palette blending with first color.
-     * @param themeGenPattern: ThemeGenPattern: The pattern to generate the theme color palette.
+     * @param themeGenMode: ThemeGenPattern: The pattern to generate the theme color palette.
      * @return A light theme color set. [ColorScheme]
      */
-    private fun generateMultiInputThemeLightColorScheme(givenColor: Color, secondColor: Color, blendColor: Color? = null, themeGenPattern: ThemeGenPattern = ThemeGenPattern.SEQUENCE): ColorScheme {
-        when (themeGenPattern) {
-            ThemeGenPattern.SEQUENCE -> {
+    private fun generateMultiInputThemeLightColorScheme(givenColor: Color, secondColor: Color, blendColor: Color? = null, themeGenMode: ThemeGenMode = ThemeGenMode.SEQUENCE): ColorScheme {
+        when (themeGenMode) {
+            ThemeGenMode.SEQUENCE -> {
                 val light = lightColorScheme(
                     primary = givenColor,
                     secondary = secondColor,
@@ -131,7 +131,7 @@ object ThemeGenUtil {
 
                 return light
             }
-            ThemeGenPattern.BLEND -> {
+            ThemeGenMode.BLEND -> {
                 val blend = blendColor ?: run { givenColor }
                 val light = lightColorScheme(
                     primary = givenColor,
@@ -172,12 +172,12 @@ object ThemeGenUtil {
      * Generate dark theme color set for given color.
      * @param givenColor The color to generate the theme color palette for.
      * @param secondColor The secondary color to generate the theme color palette blending with first color.
-     * @param themeGenPattern: ThemeGenPattern: The pattern to generate the theme color palette.
+     * @param themeGenMode: ThemeGenPattern: The pattern to generate the theme color palette.
      * @return A dark theme color set. [ColorScheme]
      */
-    private fun generateMultiInputThemeDarkColorScheme(givenColor: Color, secondColor: Color, blendColor: Color? = null, themeGenPattern: ThemeGenPattern = ThemeGenPattern.SEQUENCE): ColorScheme {
-        when (themeGenPattern) {
-            ThemeGenPattern.SEQUENCE -> {
+    private fun generateMultiInputThemeDarkColorScheme(givenColor: Color, secondColor: Color, blendColor: Color? = null, themeGenMode: ThemeGenMode = ThemeGenMode.SEQUENCE): ColorScheme {
+        when (themeGenMode) {
+            ThemeGenMode.SEQUENCE -> {
                 val dark = darkColorScheme(
                     primary = generateDarkPrimaryColor(givenColor),
                     secondary = generateDarkSecondaryColor(secondColor),
@@ -190,7 +190,7 @@ object ThemeGenUtil {
 
                 return dark
             }
-            ThemeGenPattern.BLEND -> {
+            ThemeGenMode.BLEND -> {
                 val blend = blendColor ?: run { givenColor }
                 val dark = darkColorScheme(
                     primary = generateDarkPrimaryColor(givenColor),

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.Color
 import com.kavi.droid.color.palette.extension.base
 import com.kavi.droid.color.palette.extension.hsl
 import com.kavi.droid.color.palette.model.ColorSchemeThemePalette
+import com.kavi.droid.color.palette.model.ThemeGenPattern
 
 object ThemeGenUtil {
 
@@ -38,9 +39,23 @@ object ThemeGenUtil {
      * @param givenColor The color to generate theme color set.
      * @return A theme color set. [ColorSchemeThemePalette]
      */
-    internal fun generateThemeColorScheme(givenColor: Color): ColorSchemeThemePalette {
+    internal fun singleColorThemeColorScheme(givenColor: Color): ColorSchemeThemePalette {
         val lightColorPalette = generateThemeLightColorScheme(givenColor)
         val darkColorPalette = generateThemeDarkColorScheme(givenColor)
+
+        return ColorSchemeThemePalette(lightColorScheme = lightColorPalette, darkColorScheme = darkColorPalette)
+    }
+
+    internal fun multiColorInputThemeColorScheme(givenColor: Color, secondColor: Color, bias: Float = 0.5f, themeGenPattern: ThemeGenPattern = ThemeGenPattern.SEQUENCE): ColorSchemeThemePalette {
+        var blendColor: Color? = null
+
+        blendColor = when (themeGenPattern) {
+            ThemeGenPattern.SEQUENCE -> { null }
+            ThemeGenPattern.BLEND -> { ColorUtil.blendColors(firstColor = givenColor, secondColor = secondColor, bias = bias) }
+        }
+
+        val lightColorPalette = generateMultiInputThemeLightColorScheme(givenColor = givenColor, secondColor = secondColor, blendColor = blendColor, themeGenPattern = themeGenPattern)
+        val darkColorPalette = generateMultiInputThemeDarkColorScheme(givenColor = givenColor, secondColor = secondColor, blendColor = blendColor, themeGenPattern = themeGenPattern)
 
         return ColorSchemeThemePalette(lightColorScheme = lightColorPalette, darkColorScheme = darkColorPalette)
     }
@@ -80,6 +95,38 @@ object ThemeGenUtil {
         return lightColorScheme
     }
 
+    private fun generateMultiInputThemeLightColorScheme(givenColor: Color, secondColor: Color, blendColor: Color? = null, themeGenPattern: ThemeGenPattern = ThemeGenPattern.SEQUENCE): ColorScheme {
+        when (themeGenPattern) {
+            ThemeGenPattern.SEQUENCE -> {
+                val light = lightColorScheme(
+                    primary = givenColor,
+                    secondary = secondColor,
+                    tertiary = generateLightTertiaryColor(givenColor),
+                    background = generateLightBackgroundColor(givenColor),
+                    onPrimary = Color.White,
+                    onSecondary = Color.White
+                )
+                light.base = givenColor
+
+                return light
+            }
+            ThemeGenPattern.BLEND -> {
+                val blend = blendColor ?: run { givenColor }
+                val light = lightColorScheme(
+                    primary = givenColor,
+                    secondary = secondColor,
+                    tertiary = generateLightTertiaryColor(blend),
+                    background = generateLightBackgroundColor(blend),
+                    onPrimary = Color.White,
+                    onSecondary = Color.White
+                )
+                light.base = blend
+
+                return light
+            }
+        }
+    }
+
     /**
      * Generate dark theme color set for given color.
      * @param givenColor he color to generate theme color set.
@@ -98,6 +145,38 @@ object ThemeGenUtil {
         darkColorScheme.base = givenColor
 
         return darkColorScheme
+    }
+
+    private fun generateMultiInputThemeDarkColorScheme(givenColor: Color, secondColor: Color, blendColor: Color? = null, themeGenPattern: ThemeGenPattern = ThemeGenPattern.SEQUENCE): ColorScheme {
+        when (themeGenPattern) {
+            ThemeGenPattern.SEQUENCE -> {
+                val dark = darkColorScheme(
+                    primary = generateDarkPrimaryColor(givenColor),
+                    secondary = generateDarkSecondaryColor(secondColor),
+                    tertiary = generateDarkTertiaryColor(givenColor),
+                    background = generateDarkBackgroundColor(givenColor),
+                    onPrimary = Color.White,
+                    onSecondary = Color.White,
+                )
+                dark.base = givenColor
+
+                return dark
+            }
+            ThemeGenPattern.BLEND -> {
+                val blend = blendColor ?: run { givenColor }
+                val dark = darkColorScheme(
+                    primary = generateDarkPrimaryColor(givenColor),
+                    secondary = generateDarkSecondaryColor(secondColor),
+                    tertiary = generateDarkTertiaryColor(blend),
+                    background = generateDarkBackgroundColor(blend),
+                    onPrimary = Color.White,
+                    onSecondary = Color.White,
+                )
+                dark.base = blend
+
+                return dark
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
# Two color inputs for theme generation
This introduce user can generate a theme with two color inputs. Reason for this is some apps will have two colors for there design. 

#### commits:
* [Fixed the issue in color blending logic](https://github.com/KvColorPalette/KvColorPalette-Android/commit/eb1b00e08d514f9879dba2c56594c07ebb745180)
* [Created the code documentation and method comments for new change.](https://github.com/KvColorPalette/KvColorPalette-Android/commit/e53e48ce1aa8437296662007a35f8c3ea0eeb0fd)
* [Introduce a new initialize method to initiate the KvColorPalette with…](https://github.com/KvColorPalette/KvColorPalette-Android/commit/8ff9db0698404eaa0c1825e70b81257262628770)
* [Introduce new methods to generate theme palette using 2 input colors.](https://github.com/KvColorPalette/KvColorPalette-Android/commit/e652b1d2585745834b30727213eaffe6c0b06e7b)
* [Introduce new method to ColorUtil.kt for blend two colors.](https://github.com/KvColorPalette/KvColorPalette-Android/commit/a019850416d71e235c15d6c81a8e5ccfd2dc0b12)
* [Remove all deprecated functionality for the new release.](https://github.com/KvColorPalette/KvColorPalette-Android/commit/f379919fbe76ec10be443835378afba38c3bce4a)