### PR TITLE
Feature/introduce new inverse colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,19 +94,22 @@ override fun onCreate() {
 This initiation create a color schemas for a theme using the given color at the initiation. This generated color schemas will available for light and dark theme variants.
 
 In this `KvColorPalette.colorSchemeThemePalette` you will have following color attributes.
-|Attribute    |light-theme |dark-theme  |Description   |
-|-------------|------------|------------|--------------|
-|.base        |original    |original    |This is the base color given by the user.   |
-|.primary     |available   |available   |Suggesting primary color. This color can use for buttons, major component etc.   |
-|.secondary   |available   |available   |Suggesting secondary color. For any the secondary components which should not use by primary color.   |
-|.tertiary    |available   |available   |Suggesting tertiary color.   |
-|.quaternary  |available   |available   |Suggesting quaternary color.   |
-|.background  |available   |available   |Suggesting background color.   |
-|.surface     |available   |available   |Suggesting background color.   |
-|.onPrimary   |available   |available   |This is the color you can use on any component use primary color.   |
-|.onSecondary |available   |available   |This is the color you can use on any component use secondary color.   |
-|.onSurface   |available   |available   |This is the color you can use on any component use secondary color.   |
-|.shadow      |available   |available   |This is the color for your shadows.   |
+|Attribute              |light-theme |dark-theme  |Description   |
+|-----------------------|------------|------------|--------------|
+|.base                  |original    |original    |This is the base color given by the user.   |
+|.default               |available   |available   |This color defines LightMode -> White, DarkMode -> Black.   |
+|.primary               |available   |available   |Suggesting primary color. This color can use for buttons, major component etc.   |
+|.secondary             |available   |available   |Suggesting secondary color. For any the secondary components which should not use by primary color.   |
+|.tertiary              |available   |available   |Suggesting tertiary color.   |
+|.quaternary            |available   |available   |Suggesting quaternary color.   |
+|.background            |available   |available   |Suggesting background color.   |
+|.surface               |available   |available   |Suggesting background color.   |
+|.onPrimary             |available   |available   |This is the color you can use on any component use primary color.   |
+|.onSecondary           |available   |available   |This is the color you can use on any component use secondary color.   |
+|.onSurface             |available   |available   |This is the color you can use on any component use secondary color.   |
+|.shadow                |available   |available   |This is the color for your shadows.   |
+|.inverseOnPrimary      |available   |available   |This is the inverse color of onPrimary color.   |
+|.inverseOnBackground   |available   |available   |This is the inverse color of onBackground color.   |
 
 This `ColorSchemaThemePalette` is another Android Jetpack Compose `ColorSchema`. But that contains additional attributes like `base`, `quaternary`, `shadow` that provide 
 by the `KvColorPalette-Android` library. All above table mentioned colors are generated according to the given color and created the `ColorScheme`.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ In this `KvColorPalette.colorSchemeThemePalette` you will have following color a
 |.onSecondary           |available   |available   |This is the color you can use on any component use secondary color.   |
 |.onSurface             |available   |available   |This is the color you can use on any component use secondary color.   |
 |.shadow                |available   |available   |This is the color for your shadows.   |
+|.inverseDefault        |available   |available   |This color defines LightMode -> Black, DarkMode -> White.   |
 |.inverseOnPrimary      |available   |available   |This is the inverse color of onPrimary color.   |
 |.inverseOnBackground   |available   |available   |This is the inverse color of onBackground color.   |
 

--- a/gradle/version-catalog/libs.versions.toml
+++ b/gradle/version-catalog/libs.versions.toml
@@ -1,23 +1,19 @@
 [versions]
 minSdkVersion = "26"
-compilerSdkVersion = "35"
-targetSdkVersion = "35"
+compilerSdkVersion = "36"
+targetSdkVersion = "36"
 jvmVersion = "21"
 
-agp = "8.7.3"
-kotlin = "2.0.0"
+agp = "8.13.0"
+kotlin = "2.2.0"
 dokka = "1.8.10"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.8.7"
-activityCompose = "1.10.0"
-composeBom = "2025.01.00"
-appcompat = "1.7.0"
+composeBom = "2025.07.00"
 material = "1.12.0"
 composeMaterial = "1.7.6"
-composeNavigation = "2.8.5"
 
 googleTruthVersion = "1.4.4"
 mockKVersion = "1.14.5"
@@ -26,19 +22,12 @@ mockKVersion = "1.14.5"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
-androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
-androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
-androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-material = { group = "androidx.compose.material", name = "material", version.ref = "composeMaterial"}
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "composeNavigation" }
 
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Dec 05 13:15:30 EST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kv-color-palette/build.gradle.kts
+++ b/kv-color-palette/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -34,8 +36,11 @@ android {
         sourceCompatibility = javaVersion
         targetCompatibility = javaVersion
     }
-    kotlinOptions {
-        jvmTarget = libs.versions.jvmVersion.get()
+
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.fromTarget(libs.versions.jvmVersion.get())
+        }
     }
 
     publishing {
@@ -48,7 +53,6 @@ android {
 
 dependencies {
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.appcompat)
     implementation(libs.material)
     implementation(libs.androidx.material3)
 

--- a/kv-color-palette/gradle.properties
+++ b/kv-color-palette/gradle.properties
@@ -1,3 +1,3 @@
 kvColorPaletteGroupId=com.github.KvColorPalette
 kvColorPaletteArtifactId=KvColorPalette-Android
-kvColorPaletteVersion=3.2.0
+kvColorPaletteVersion=3.3.0

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/extension/ColorSchemeExtension.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/extension/ColorSchemeExtension.kt
@@ -2,6 +2,7 @@ package com.kavi.droid.color.palette.extension
 
 import androidx.compose.material3.ColorScheme
 import androidx.compose.ui.graphics.Color
+import com.kavi.droid.color.palette.KvColorPalette
 import com.kavi.droid.color.palette.util.ThemeGenUtil
 import java.util.WeakHashMap
 
@@ -23,6 +24,13 @@ var ColorScheme.base: Color
     }
 
 /**
+ * This is for use light theme White color and dark theme Black color. This can use most of background or
+ * shadow mode with alpha value on the color according to the theme.
+ */
+val ColorScheme.default: Color
+    get() = getDefaultColor(this)
+
+/**
  * This is for use light theme primary color dark theme contrast color
  */
 val ColorScheme.quaternary: Color
@@ -33,6 +41,34 @@ val ColorScheme.quaternary: Color
  */
 val ColorScheme.shadow: Color
     get() = getShadowColor(this)
+
+/**
+ * This is for use the inverse color of onPrimary color
+ */
+val ColorScheme.inverseOnPrimary: Color
+    get() = getInverseOnPrimaryColor(this)
+
+/**
+ * This is for use the inverse color of onBackground color
+ */
+val ColorScheme.inverseOnBackground: Color
+    get() = getInverseOnBackgroundColor(this)
+
+
+/**
+ * This returns default color according to the theme mode. This method finds the mode from the
+ * theme color scheme's background color. If the background color is a lighter one, it's assume
+ * this is light mode and generate the default color.
+ *
+ * @param colorScheme: [ColorScheme] of the theme
+ * @return color: [Color] default color for theme
+ */
+private fun getDefaultColor(colorScheme: ColorScheme): Color {
+    return if (colorScheme.background.isHighLightColor)
+        Color.White
+    else
+        Color.Black
+}
 
 /**
  * This returns quaternary color according to the theme mode. This method finds the mode from the
@@ -62,4 +98,36 @@ private fun getShadowColor(colorScheme: ColorScheme): Color {
         Color.Gray
     else
         Color.White
+}
+
+/**
+ * This returns inverse onPrimary color according to the theme mode. This method finds the mode from the
+ * theme color scheme's background color. If the background color is a lighter one, it's assume
+ * this is light mode and returns the inverse of onPrimary color.
+ *
+ * @param colorScheme: [ColorScheme] of the theme
+ * @return color: [Color] inverse of onPrimary color for theme
+ */
+private fun getInverseOnPrimaryColor(colorScheme: ColorScheme): Color {
+    return if (colorScheme.background.isHighLightColor) {
+        KvColorPalette.colorSchemeThemePalette.darkColorScheme.onPrimary
+    } else {
+        KvColorPalette.colorSchemeThemePalette.lightColorScheme.onPrimary
+    }
+}
+
+/**
+ * This returns inverse onBackground color according to the theme mode. This method finds the mode from the
+ * theme color scheme's background color. If the background color is a lighter one, it's assume
+ * this is light mode and returns the inverse of onBackground color.
+ *
+ * @param colorScheme: [ColorScheme] of the theme
+ * @return color: [Color] inverse of onBackground color for theme
+ */
+private fun getInverseOnBackgroundColor(colorScheme: ColorScheme): Color {
+    return if (colorScheme.background.isHighLightColor) {
+        KvColorPalette.colorSchemeThemePalette.darkColorScheme.onBackground
+    } else {
+        KvColorPalette.colorSchemeThemePalette.lightColorScheme.onBackground
+    }
 }

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/extension/ColorSchemeExtension.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/extension/ColorSchemeExtension.kt
@@ -31,6 +31,13 @@ val ColorScheme.default: Color
     get() = getDefaultColor(this)
 
 /**
+ * This is for use light theme Black color and dark theme White color. This can use most of background or
+ * shadow mode with alpha value on the color according to the theme.
+ */
+val ColorScheme.inverseDefault: Color
+    get() = getDefaultInverseColor(this)
+
+/**
  * This is for use light theme primary color dark theme contrast color
  */
 val ColorScheme.quaternary: Color
@@ -68,6 +75,21 @@ private fun getDefaultColor(colorScheme: ColorScheme): Color {
         Color.White
     else
         Color.Black
+}
+
+/**
+ * This returns inverse of default color according to the theme mode. This method finds the mode from the
+ * theme color scheme's background color. If the background color is a lighter one, it's assume
+ * this is light mode and generate the inverse of default color.
+ *
+ * @param colorScheme: [ColorScheme] of the theme
+ * @return color: [Color] inverse of default color for theme
+ */
+private fun getDefaultInverseColor(colorScheme: ColorScheme): Color {
+    return if (colorScheme.background.isHighLightColor)
+        Color.Black
+    else
+        Color.White
 }
 
 /**

--- a/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
+++ b/kv-color-palette/src/main/kotlin/com/kavi/droid/color/palette/util/ThemeGenUtil.kt
@@ -105,6 +105,7 @@ object ThemeGenUtil {
             tertiary = generateLightTertiaryColor(givenColor),
             background = backgroundColor,
             surface = ColorUtil.blendColors(firstColor = backgroundColor, secondColor = Color.White, .9f),
+            scrim = Color.Black,
             onPrimary = generateOverTheTopLightColor(givenColor),
             onSecondary = generateOverTheTopLightColor(secondaryColor),
             onSurface = ColorUtil.blendColors(firstColor = Color.Black, Color.White, .25f)
@@ -131,6 +132,7 @@ object ThemeGenUtil {
                     tertiary = generateLightTertiaryColor(givenColor),
                     background = backgroundColor,
                     surface = ColorUtil.blendColors(firstColor = backgroundColor, secondColor = Color.White, .9f),
+                    scrim = Color.Black,
                     onPrimary = generateOverTheTopLightColor(givenColor),
                     onSecondary = generateOverTheTopLightColor(secondColor),
                     onSurface = ColorUtil.blendColors(firstColor = Color.Black, Color.White, .25f)
@@ -148,6 +150,7 @@ object ThemeGenUtil {
                     tertiary = generateLightTertiaryColor(blend),
                     background = backgroundColor,
                     surface = ColorUtil.blendColors(firstColor = backgroundColor, secondColor = Color.White, .9f),
+                    scrim = Color.Black,
                     onPrimary = generateOverTheTopLightColor(givenColor),
                     onSecondary = generateOverTheTopLightColor(secondColor),
                     onSurface = ColorUtil.blendColors(firstColor = Color.Black, Color.White, .25f)
@@ -174,6 +177,7 @@ object ThemeGenUtil {
             tertiary = generateDarkTertiaryColor(givenColor),
             background = darkBackground,
             surface = ColorUtil.blendColors(firstColor = darkBackground, secondColor = Color.Black, .9f),
+            scrim = Color.White,
             onPrimary = ColorUtil.blendColors(firstColor = darkPrimary, secondColor = Color.White, .9f),
             onSecondary = ColorUtil.blendColors(firstColor = darkSecondary, secondColor = Color.White, .9f),
             onSurface = Color.White
@@ -203,6 +207,7 @@ object ThemeGenUtil {
                     tertiary = generateDarkTertiaryColor(givenColor),
                     background = darkBackground,
                     surface = ColorUtil.blendColors(firstColor = darkBackground, secondColor = Color.Black, .9f),
+                    scrim = Color.White,
                     onPrimary = ColorUtil.blendColors(firstColor = darkPrimary, secondColor = Color.White, .9f),
                     onSecondary = ColorUtil.blendColors(firstColor = darkSecondary, secondColor = Color.White, .9f),
                     onSurface = Color.White
@@ -222,6 +227,7 @@ object ThemeGenUtil {
                     tertiary = generateDarkTertiaryColor(blend),
                     background = darkBackground,
                     surface = ColorUtil.blendColors(firstColor = darkBackground, secondColor = Color.Black, .9f),
+                    scrim = Color.White,
                     onPrimary = ColorUtil.blendColors(firstColor = darkPrimary, secondColor = Color.White, .9f),
                     onSecondary = ColorUtil.blendColors(firstColor = darkSecondary, secondColor = Color.White, .9f),
                     onSurface = Color.White
@@ -255,6 +261,9 @@ object ThemeGenUtil {
         return Color.hsl(hue = primaryColor.hsl.hue, saturation = .4f, lightness = .95f)
     }
 
+    /**
+     * Generate onPrimary color according to the selected primary color
+     */
     private fun generateOverTheTopLightColor(givenColor: Color): Color {
         return if (givenColor.isHighLightColor) {
             ColorUtil.blendColors(firstColor = givenColor, Color.Black, .6f)


### PR DESCRIPTION
# Additional color to theme palette
This change introduce new inverse colors to the theme palette. With inverse of `onPrimary` and `onBackground` colors, there is another color call `default` & `inverseDefault`. This default color is always `White` for light mode and `Black` for dark mode and inverse default is in the other way.

#### commits:
* [Update the library version](https://github.com/KvColorPalette/KvColorPalette-Android/commit/3a4237d18f3a9a9fb1195e3255812d6964e6b5cf)
* [Update the README.md](https://github.com/KvColorPalette/KvColorPalette-Android/commit/c4f5296152435ee24f14a24c04b036f16f247458)
* [Start to use gradle-wrapper v9.0.0 and update few dependencies that u…](https://github.com/KvColorPalette/KvColorPalette-Android/commit/e89af4496d25fe5554fb1ca7fd3fdb36a83679a9)
* [Introduce few inverse color to the theme palette](https://github.com/KvColorPalette/KvColorPalette-Android/commit/857c4baad2487c1844259a275d9a73ab6f4d258e)